### PR TITLE
Typo (verb form agreement)

### DIFF
--- a/bin/paperback
+++ b/bin/paperback
@@ -11,7 +11,7 @@ __END__
 
 =head1 NAME
 
-paperback - imposition of PDF pages for signature printing and bounding
+paperback - imposition of PDF pages for signature printing and binding
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
"Printing and binding" (not "bounding" unless this refers to the bounds or sizes of things).  